### PR TITLE
Fix for detection of marked content position

### DIFF
--- a/src/core/bounding_boxes.js
+++ b/src/core/bounding_boxes.js
@@ -520,7 +520,8 @@ class BoundingBoxesCalculator {
       fn !== OPS.markPoint &&
       fn !== OPS.markPointProps &&
       fn !== OPS.beginMarkedContent &&
-      fn !== OPS.beginMarkedContentProps
+      fn !== OPS.beginMarkedContentProps &&
+      fn !== OPS.endMarkedContent
     ) {
       this.boundingBoxesStack.inc();
     }

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1817,15 +1817,20 @@ class ExtendedCatalog extends Catalog {
         const roleName = this.getRoleName(el, name);
 
         const treeElement = {
-          name: name ? stringToUTF8String(name) : null,
-          roleName: roleName ? stringToUTF8String(roleName) : null,
+          name: name ? stringToPDFString(name) : null,
+          roleName: roleName ? stringToPDFString(roleName) : null,
           children: this.getTreeElement(el.get("K"), page, el.getRaw("K")),
           pageIndex: page,
           ref: ref instanceof Ref ? ref : null,
         };
 
-        const alt = el.has("Alt") ? el.get("Alt") : null;
-        if (alt) treeElement.alt = stringToUTF8String(alt);
+        let alt = el.has("Alt") ? el.get("Alt") : null;
+        if (typeof alt !== "string") {
+          alt = el.has("ActualText") ? el.get("ActualText") : null;
+        }
+        if (typeof alt === "string") {
+          treeElement.alt = stringToPDFString(alt);
+        }
 
         return treeElement;
       }
@@ -1898,15 +1903,20 @@ class ExtendedCatalog extends Catalog {
         const roleName = this.getRoleName(el, name);
 
         const treeElement = {
-          name: name ? stringToUTF8String(name) : null,
-          roleName: roleName ? stringToUTF8String(roleName) : null,
+          name: name ? stringToPDFString(name) : null,
+          roleName: roleName ? stringToPDFString(roleName) : null,
           children: [],
           pageIndex: page,
           ref: ref instanceof Ref ? ref : null,
         };
 
-        const alt = el.has("Alt") ? el.get("Alt") : null;
-        if (alt) treeElement.alt = stringToUTF8String(alt);
+        let alt = el.has("Alt") ? el.get("Alt") : null;
+        if (typeof alt !== "string") {
+          alt = el.has("ActualText") ? el.get("ActualText") : null;
+        }
+        if (typeof alt === "string") {
+          treeElement.alt = stringToPDFString(alt);
+        }
 
         return treeElement;
       }


### PR DESCRIPTION
Closes https://trello.com/c/ttjRjDxc

PR includes the following changes:

- Removed `EMC` (`OPS.endMarkedContent`) operator from the list of operators that are processed as ones inside the content item. This prevents us from forming unnecessary content items each time we meet the end of the content item block. 
- Replaced simple strings conversion to UTF-8 with a proper and safe one (`stringToPDFString`) during the structure tree parsing. This fixes `Failed to parse structure tree element: URI malformed` errors and ensures we do not throw the whole structure element away in case it includes a string that cannot be fully decoded. 