### PR TITLE
Fix issue with names decoding

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1802,9 +1802,9 @@ class ExtendedCatalog extends Catalog {
     try {
       return stringToUTF8String(str);
     } catch (e) {
-      console.log(
+      /*console.log(
         `Failed to convert string "${str}" (${type}) to UTF-8, using safe conversion. Error: ${e}`
-      );
+      );*/
       return stringToPDFString(str);
     }
   }

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1798,6 +1798,17 @@ class ExtendedCatalog extends Catalog {
     return shadow(this, "structTreeRootObject", structTreeRoot);
   }
 
+  convertString(str, type) {
+    try {
+      return stringToUTF8String(str);
+    } catch (e) {
+      console.log(
+        `Failed to convert string "${str}" (${type}) to UTF-8, using safe conversion. Error: ${e}`
+      );
+      return stringToPDFString(str);
+    }
+  }
+
   getTreeElement(el, page, ref) {
     try {
       // update page for current element
@@ -1817,8 +1828,8 @@ class ExtendedCatalog extends Catalog {
         const roleName = this.getRoleName(el, name);
 
         const treeElement = {
-          name: name ? stringToPDFString(name) : null,
-          roleName: roleName ? stringToPDFString(roleName) : null,
+          name: name ? this.convertString(name, "Name") : null,
+          roleName: roleName ? this.convertString(roleName, "Role name") : null,
           children: this.getTreeElement(el.get("K"), page, el.getRaw("K")),
           pageIndex: page,
           ref: ref instanceof Ref ? ref : null,
@@ -1829,7 +1840,7 @@ class ExtendedCatalog extends Catalog {
           alt = el.has("ActualText") ? el.get("ActualText") : null;
         }
         if (typeof alt === "string") {
-          treeElement.alt = stringToPDFString(alt);
+          treeElement.alt = this.convertString(alt, "Alt");
         }
 
         return treeElement;
@@ -1903,8 +1914,8 @@ class ExtendedCatalog extends Catalog {
         const roleName = this.getRoleName(el, name);
 
         const treeElement = {
-          name: name ? stringToPDFString(name) : null,
-          roleName: roleName ? stringToPDFString(roleName) : null,
+          name: name ? this.convertString(name, "Name") : null,
+          roleName: roleName ? this.convertString(roleName, "Role name") : null,
           children: [],
           pageIndex: page,
           ref: ref instanceof Ref ? ref : null,
@@ -1915,7 +1926,7 @@ class ExtendedCatalog extends Catalog {
           alt = el.has("ActualText") ? el.get("ActualText") : null;
         }
         if (typeof alt === "string") {
-          treeElement.alt = stringToPDFString(alt);
+          treeElement.alt = this.convertString(alt, "Alt");
         }
 
         return treeElement;


### PR DESCRIPTION
Closes: ![](https://github.trello.services/images/mini-trello-icon.png) [Wrong structure element names](https://trello.com/c/CFpMncQe/748-wrong-structure-element-names)

PR includes the following changes:
- Added a method to convert strings to UTF-8. This method first try classic `decodeURIComponent` conversion and if it fails uses a safe `stringToPDFString` method